### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: PeterStrick.ViVeTool-GUI
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

I already have a PR to add ViveTool-GUI to winget-pkgs (https://github.com/microsoft/winget-pkgs/pull/66613); this workflow would be used to update it.

Before merging this:
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![image](https://user-images.githubusercontent.com/56180050/179500169-e5ae9417-6108-409b-b34e-5a42cb9dea28.png)

2. Fork https://github.com/microsoft/winget-pkgs under @PeterStrick. The action will use that fork for making a branch and merging it with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Sign the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs as you will be a first-time contributor.


If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro) and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).


