### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: PeterStrick.ViVeTool-GUI
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser is now switching to version tags instead of the `latest` tag.

As mentioned in https://github.com/PeterStrick/ViVeTool-GUI/pull/26#issuecomment-1260249225, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.